### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Label Printing
 
-Requires at least: 6.2
-Tested up to: 6.3.1
-Requires PHP: 7.4
-Stable tag: 0.2.0
-License: GPL3+
-Contributors: carstenbach
+Stable tag: 0.2.1
+Tested up to: 6.5.3
+Requires at least: 6.3
+Requires PHP: 8.1
+License: GPL v3 or later
 Tags: Label, print, print.css, block
-
+Contributors: carstenbach
 
 ![](.wordpress-org/banner-1544x500.png)
 
@@ -116,7 +115,7 @@ The installation process for the ***Label Printing* block** plugin is straightfo
 
 ### Installation from within WordPress
 
-1. Visit **Plugins** > Add New**.
+1. Visit **Plugins** > **Add New**.
 2. Search for **Label Printing**.
 3. Install and activate the Label Printing plugin.
 
@@ -128,12 +127,17 @@ The installation process for the ***Label Printing* block** plugin is straightfo
 
 ### Install via composer
 
-1. Install via command line
-    ```sh
-    composer require figuren-theater/label-printing
-    ```
+1. Install via command line `composer require figuren-theater/label-printing`
 2. Visit **Plugins**.
 3. Activate the Label Printing plugin.
+
+## Screenshots
+
+1. Insert the Label Printing block
+2. Choose your pre-defined Label
+3. Switch visually between different label presets
+4. Fill in your label content
+5. Check everything in your browsers print dialog, exclude pages with header and footer and finally print your labels.
 
 ## Frequently Asked Questions
 
@@ -141,42 +145,42 @@ The installation process for the ***Label Printing* block** plugin is straightfo
 
 The default labels, if not changed via the `Figuren_Theater\Label_Printing\Patterns\bootstrap_labels` filter, are:
 
-```php
-$bootstrap_labels = [
-	[
-		'name'         => 'A6 Landscape',
-		'width'        => 148,
-		'height'       => 105,
-		'a4_border_tb' => 0,
-		'a4_border_lr' => 0,
-		'orientation'  => 'landscape',
-	],
-	[
-		'name'         => 'A6 Landscape (with Top-Bottom-Borders)',
-		'width'        => 148,
-		'height'       => 90,
-		'a4_border_tb' => 15,
-		'a4_border_lr' => 0,
-		'orientation'  => 'landscape',
-	],
-	[
-		'name'         => 'A8 Portrait',
-		'width'        => 52.5,
-		'height'       => 74,
-		'a4_border_tb' => 0,
-		'a4_border_lr' => 0,
-		'orientation'  => 'portrait',
-	],
-	[
-		'name'         => 'A8 Landscape',
-		'width'        => 74,
-		'height'       => 52.5,
-		'a4_border_tb' => 0,
-		'a4_border_lr' => 0,
-		'orientation'  => 'landscape',
-	],
-];
-```
+	`
+	\$bootstrap_labels = [
+		[
+			'name'         => 'A6 Landscape',
+			'width'        => 148,
+			'height'       => 105,
+			'a4_border_tb' => 0,
+			'a4_border_lr' => 0,
+			'orientation'  => 'landscape',
+		],
+		[
+			'name'         => 'A6 Landscape (with Top-Bottom-Borders)',
+			'width'        => 148,
+			'height'       => 90,
+			'a4_border_tb' => 15,
+			'a4_border_lr' => 0,
+			'orientation'  => 'landscape',
+		],
+		[
+			'name'         => 'A8 Portrait',
+			'width'        => 52.5,
+			'height'       => 74,
+			'a4_border_tb' => 0,
+			'a4_border_lr' => 0,
+			'orientation'  => 'portrait',
+		],
+		[
+			'name'         => 'A8 Landscape',
+			'width'        => 74,
+			'height'       => 52.5,
+			'a4_border_tb' => 0,
+			'a4_border_lr' => 0,
+			'orientation'  => 'landscape',
+		],
+	];
+	`
 
 ### Why should I use a `blank.php` template
 
@@ -222,13 +226,10 @@ Depending on your selected **pre-defined label** the `…/label-proxy` block wil
    - de_DE
    - de_DE_formal
 
-## Screenshots
+## Upgrade Notice
 
-1. Insert the Label Printing block
-2. Choose your pre-defined Label
-3. Switch visually between different label presets
-4. Fill in your label content
-5. Check everything in your browsers print dialog, exclude pages with header and footer and finally print your labels.
+(silence is golden)
+
+## Changelog
 
 <!-- changelog -->
-

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ Make sure to only *print* what you really need. If the Print Preview in your bro
 
 Using a `blank.php` template ensures that only the necessary content is printed. If your theme provides this template, it's the best choice to avoid unnecessary headers, post titles, and footers in your printed materials.
 
+### How does the block work?
+
+`figuren-theater/label-printing` is a custom block that uses normal `innerBlocks` to keep the blocks, you are going to add to your label.
+
+To preview the block in the editor and also to render it on the front-end, it uses a hidden, second block called `figuren-theater/label-proxy`. This is a lightweight version of a reusable block, that only works within one post, and not across multiples.
+
+Depending on your selected **pre-defined label** the `…/label-proxy` block will be duplicated as often as the dimensions of the selected label allow. In other words, your label will be fitted into an A4 print-template as often as possible.
+
+
+
 ## Standards and best-practices, this plugin follows
 
 - ✅ This project is licensed under the **GPL-3.0-or-later**, see the LICENSE file for details

--- a/inc/block-styles/namespace.php
+++ b/inc/block-styles/namespace.php
@@ -14,7 +14,7 @@ namespace Figuren_Theater\Label_Printing\Block_Styles;
  *
  * @return void
  */
-function register() :void {
+function register(): void {
 	\add_action( 'init', __NAMESPACE__ . '\\bootstrap', 1 );
 }
 
@@ -29,7 +29,7 @@ function register() :void {
  *
  * @return void
  */
-function bootstrap() :void {
+function bootstrap(): void {
 
 	// Register A4 portrait block style.
 	\register_block_style(
@@ -53,7 +53,7 @@ function bootstrap() :void {
 		]
 	);
 
-	\add_filter('body_class', __NAMESPACE__ . '\\body_class');
+	\add_filter( 'body_class', __NAMESPACE__ . '\\body_class' );
 }
 
 /**

--- a/inc/block-styles/namespace.php
+++ b/inc/block-styles/namespace.php
@@ -62,7 +62,7 @@ function bootstrap(): void {
  * @see https://developer.wordpress.org/reference/hooks/body_class/
  * @see https://developer.wordpress.org/reference/functions/has_block/
  *
- * @param  string[] $classes
+ * @param  string[] $classes CSS classes that will be added to the <body> element by WordPress.
  *
  * @return string[]
  */

--- a/inc/block-styles/namespace.php
+++ b/inc/block-styles/namespace.php
@@ -52,5 +52,28 @@ function bootstrap() :void {
 			'inline_style' => '.wp-block-group.is-style-label-overview-landscape { --label-printing-doc-width: 29.7cm; --label-printing-doc-height: 21cm }',
 		]
 	);
+
+	\add_filter('body_class', __NAMESPACE__ . '\\body_class');
 }
 
+/**
+ * Add a CSS class to the <body> element if 'label-printing' block is present and is a singular-view.
+ *
+ * @see https://developer.wordpress.org/reference/hooks/body_class/
+ * @see https://developer.wordpress.org/reference/functions/has_block/
+ *
+ * @param  string[] $classes
+ *
+ * @return string[]
+ */
+function body_class( array $classes ): array {
+
+	if ( ! \is_singular() || \is_admin() ) {
+		return $classes;
+	}
+
+	if ( \has_block( 'figuren-theater/label-printing' ) ) {
+		$classes[] = 'is-label-printing';
+	}
+	return $classes;
+}

--- a/inc/block-variations/namespace.php
+++ b/inc/block-variations/namespace.php
@@ -61,7 +61,7 @@ function register_asset( string $asset ): void {
 	if ( ! file_exists( $script_asset_path ) ) {
 		if ( \in_array( wp_get_environment_type(), [ 'local', 'development' ], true ) ) {
 			throw new \Error(
-				$error_message
+				\esc_html( $error_message )
 			);
 		} else {
 			\error_log( $error_message );

--- a/inc/block-variations/namespace.php
+++ b/inc/block-variations/namespace.php
@@ -64,7 +64,7 @@ function register_asset( string $asset ): void {
 				\esc_html( $error_message )
 			);
 		} else {
-			\error_log( $error_message );
+			\error_log( $error_message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			return;
 		}
 	}

--- a/inc/block-variations/namespace.php
+++ b/inc/block-variations/namespace.php
@@ -14,7 +14,7 @@ use Figuren_Theater\Label_Printing;
  *
  * @return void
  */
-function register() :void {
+function register(): void {
 		\add_action( 'init', __NAMESPACE__ . '\\register_assets', 5 );
 		\add_action( 'enqueue_block_editor_assets', __NAMESPACE__ . '\\enqueue_assets' );
 }
@@ -24,7 +24,7 @@ function register() :void {
  *
  * @return void
  */
-function register_assets() :void {
+function register_assets(): void {
 	\array_map( __NAMESPACE__ . '\\register_asset', get_assets() );
 }
 
@@ -33,7 +33,7 @@ function register_assets() :void {
  *
  * @return string[] Array of asset slugs.
  */
-function get_assets() : array {
+function get_assets(): array {
 	return [
 		'label-overview',
 	];
@@ -48,7 +48,7 @@ function get_assets() : array {
  *
  * @return void
  */
-function register_asset( string $asset ) : void {
+function register_asset( string $asset ): void {
 
 	$dir = Label_Printing\DIRECTORY;
 
@@ -91,7 +91,7 @@ function register_asset( string $asset ) : void {
  *
  * @return void
  */
-function enqueue_assets() : void {
+function enqueue_assets(): void {
 	\array_map( __NAMESPACE__ . '\\enqueue_asset', get_assets() );
 }
 
@@ -102,6 +102,6 @@ function enqueue_assets() : void {
  *
  * @return void
  */
-function enqueue_asset( string $asset ) : void {
+function enqueue_asset( string $asset ): void {
 	wp_enqueue_script( "label-printing--$asset" );
 }

--- a/inc/block-variations/namespace.php
+++ b/inc/block-variations/namespace.php
@@ -59,7 +59,7 @@ function register_asset( string $asset ): void {
 	$error_message = "You need to run `npm start` or `npm run build` for the '$asset' block-asset first.";
 
 	if ( ! file_exists( $script_asset_path ) ) {
-		if ( \in_array( wp_get_environment_type(), [ 'local', 'development' ], true ) ) {
+		if ( \in_array( \wp_get_environment_type(), [ 'local', 'development' ], true ) ) {
 			throw new \Error(
 				\esc_html( $error_message )
 			);
@@ -72,14 +72,14 @@ function register_asset( string $asset ): void {
 	$index_js     = "$path/$asset.js";
 	$script_asset = require $script_asset_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 
-	wp_register_script(
+	\wp_register_script(
 		"label-printing--$asset",
-		plugins_url( $index_js, "$dir/plugin.php" ),
+		\plugins_url( $index_js, "$dir/plugin.php" ),
 		$script_asset['dependencies'],
 		$script_asset['version']
 	);
 
-	wp_set_script_translations(
+	\wp_set_script_translations(
 		"label-printing--$asset",
 		'label-printing',
 		"$dir/languages"
@@ -103,5 +103,5 @@ function enqueue_assets(): void {
  * @return void
  */
 function enqueue_asset( string $asset ): void {
-	wp_enqueue_script( "label-printing--$asset" );
+	\wp_enqueue_script( "label-printing--$asset" );
 }

--- a/inc/block-variations/namespace.php
+++ b/inc/block-variations/namespace.php
@@ -76,7 +76,8 @@ function register_asset( string $asset ): void {
 		"label-printing--$asset",
 		\plugins_url( $index_js, "$dir/plugin.php" ),
 		$script_asset['dependencies'],
-		$script_asset['version']
+		$script_asset['version'],
+		true
 	);
 
 	\wp_set_script_translations(

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -14,7 +14,7 @@ use Figuren_Theater\Label_Printing;
  *
  * @return void
  */
-function register() :void {
+function register(): void {
 	\add_action( 'init', __NAMESPACE__ . '\\bootstrap' );
 }
 
@@ -23,9 +23,8 @@ function register() :void {
  *
  * @return void
  */
-function bootstrap() :void {
+function bootstrap(): void {
 	register_blocks();
-
 }
 
 /**
@@ -33,7 +32,7 @@ function bootstrap() :void {
  *
  * @return string[] Array of block slugs.
  */
-function get_blocks() : array {
+function get_blocks(): array {
 	return [
 		'label-printing',
 		'label-proxy',
@@ -45,7 +44,7 @@ function get_blocks() : array {
  *
  * @return void
  */
-function register_blocks() : void {
+function register_blocks(): void {
 	\array_map( __NAMESPACE__ . '\\register_block', get_blocks() );
 }
 
@@ -56,7 +55,7 @@ function register_blocks() : void {
  *
  * @return void
  */
-function register_block( string $block ) : void {
+function register_block( string $block ): void {
 
 	require_once Label_Printing\DIRECTORY . '/build/' . $block . '/index.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 
@@ -83,6 +82,6 @@ function register_block( string $block ) : void {
  *
  * @return string Namespaced block name.
  */
-function get_ns_name( string $block ) : string {
+function get_ns_name( string $block ): string {
 	return \ucfirst( \str_replace( 'label-', '', $block ) );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -12,7 +12,7 @@ namespace Figuren_Theater\Label_Printing;
  *
  * @return void
  */
-function register() :void {
+function register(): void {
 
 	\load_plugin_textdomain(
 		'label-printing',

--- a/inc/patterns/class-generator.php
+++ b/inc/patterns/class-generator.php
@@ -39,7 +39,7 @@ class Generator {
 	/**
 	 * Setup a new Pattern Generator with a pre-defined Label.
 	 *
-	 * @param  Label $label Printing-Label
+	 * @param  Label $label The Printing-Label object with all measurements & dimensions.
 	 */
 	public function __construct( Label $label ) {
 		$this->label = $label;

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -48,7 +48,7 @@ class Label_Store {
 
 		// Prepare Data.
 		$post = \get_post( $post );
-		if ( ! $post instanceof WP_Post ) {
+		if ( ! $post instanceof \WP_Post ) {
 			return null;
 		}
 
@@ -57,6 +57,7 @@ class Label_Store {
 			META_KEY,
 			true
 		);
+
 		if ( ! is_array( $meta ) || empty( $meta ) ) {
 			return null;
 		}
@@ -169,7 +170,7 @@ class Label_Store {
 	 */
 	protected static function label_factory_from_wp_posts( \WP_Query $query ) : array {
 		return \array_filter( \array_map(
-			function( $post ){
+			function( $post ) {
 				return static::get_label_by_post( $post );
 			},
 			$query->posts
@@ -180,7 +181,7 @@ class Label_Store {
 	 * Import a Label into the DB as new 'wp_block' post.
 	 *
 	 * @param  string $name Human-readable title of the label.
-	 * @param  array $props List of required label properties: 'width', 'height', 'a4_border_tb', 'a4_border_lr' & 'orientation'.
+	 * @param  mixed[] $props List of required label properties: 'width', 'height', 'a4_border_tb', 'a4_border_lr' & 'orientation'.
 	 *
 	 * @return Label
 	 */
@@ -259,15 +260,8 @@ class Label_Store {
 		 * Add your own labels or adjust the defaults using this filter.
 		 *
 		 * Use this hook: 'Figuren_Theater\Label_Printing\Patterns\bootstrap_labels'.
-		 * @since 0.2.0
 		 *
-		 * @phpstan-ignore-next-line phpDoc.parseError
-		 * @param {array} $bootstrap_labels List of Labels (an array of arrays) that will be inserted into the DB on import by default.
-		 *
-		 * @phpstan-ignore-next-line phpDoc.parseError
-		 * @return {array}                  List of Labels (an array of arrays) that will be inserted into the DB on import.
-		 *
-		 * @example <caption>Add your own or adjust the default labels.</caption>
+		 * @example Add this before the plugin is loaded.
 		 * \add_filter(
 		 *     'Figuren_Theater\Label_Printing\Patterns\bootstrap_labels',
 		 *     function( array $default_labels ) : array {
@@ -307,6 +301,11 @@ class Label_Store {
 		 *         ];
 		 *     }
 		 * );
+		 * @since 0.2.0
+		 *
+		 * @param array $bootstrap_labels List of Labels (an array of arrays) that will be inserted into the DB on import by default.
+		 *
+		 * @return array                  List of Labels (an array of arrays) that will be inserted into the DB on import.
 		 */
 		return \apply_filters(
 			__NAMESPACE__ . '\\bootstrap_labels',

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -169,9 +169,33 @@ class Label_Store {
 	 */
 	protected static function label_factory_from_wp_posts( \WP_Query $query ) : array {
 		return \array_filter( \array_map(
-			get_label_by_post( $post ),
+			static::get_label_by_post( $post ),
 			$query->posts
 		));
+	}
+
+	/**
+	 * Import a Label into the DB as new 'wp_block' post.
+	 *
+	 * @param  string $name Human-readable title of the label.
+	 * @param  array $props List of required label properties: 'width', 'height', 'a4_border_tb', 'a4_border_lr' & 'orientation'.
+	 *
+	 * @return Label
+	 */
+	public static function import_bootstrap_label( string $name, array $props ) : Label {
+		$label = new Label(
+			(string) $name,
+			(float) $props['width'],
+			(float) $props['height'],
+		);
+
+		$label->a4_border_tb = (float) $props['a4_border_tb'];
+		$label->a4_border_lr = (float) $props['a4_border_lr'];
+		$label->orientation  = (string) $props['orientation'];
+
+		$label->insert();
+
+		return $label;
 	}
 
 	/**
@@ -181,21 +205,9 @@ class Label_Store {
 	 */
 	public static function import_bootstrap_labels() : array {
 		return \array_map(
-			function( array $bootstrap_label ) : Label {
-				$label = new Label(
-					(string) $bootstrap_label['name'],
-					(float) $bootstrap_label['width'],
-					(float) $bootstrap_label['height'],
-				);
-
-				$label->a4_border_tb = (float) $bootstrap_label['a4_border_tb'];
-				$label->a4_border_lr = (float) $bootstrap_label['a4_border_lr'];
-				$label->orientation  = (string) $bootstrap_label['orientation'];
-
-				$label->insert();
-
-				return $label;
-			},
+			function( array $label ): void {
+				static::import_bootstrap_label( $label['name'], $label ),
+			}
 			static::get_bootstrap_labels()
 		);
 	}

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -220,7 +220,7 @@ class Label_Store {
 	public static function get_bootstrap_labels() : array {
 		$bootstrap_labels = [
 			[
-				'name'         => _x( 'A6 Landscape', 'label-printing' ),
+				'name'         => __( 'A6 Landscape', 'label-printing' ),
 				'width'        => 148,
 				'height'       => 105,
 				'a4_border_tb' => 0,
@@ -228,7 +228,7 @@ class Label_Store {
 				'orientation'  => 'landscape',
 			],
 			[
-				'name'         => _x( 'A6 Landscape (with Top-Bottom-Borders)', 'label-printing' ),
+				'name'         => __( 'A6 Landscape (with Top-Bottom-Borders)', 'label-printing' ),
 				'width'        => 148,
 				'height'       => 90,
 				'a4_border_tb' => 15,
@@ -236,7 +236,7 @@ class Label_Store {
 				'orientation'  => 'landscape',
 			],
 			[
-				'name'         => _x( 'A8 Portrait', 'label-printing' ),
+				'name'         => __( 'A8 Portrait', 'label-printing' ),
 				'width'        => 52.5,
 				'height'       => 74,
 				'a4_border_tb' => 0,
@@ -244,7 +244,7 @@ class Label_Store {
 				'orientation'  => 'portrait',
 			],
 			[
-				'name'         => _x( 'A8 Landscape', 'label-printing' ),
+				'name'         => __( 'A8 Landscape', 'label-printing' ),
 				'width'        => 74,
 				'height'       => 52.5,
 				'a4_border_tb' => 0,

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -205,8 +205,8 @@ class Label_Store {
 	 */
 	public static function import_bootstrap_labels() : array {
 		return \array_map(
-			function( array $label ): void {
-				static::import_bootstrap_label( $label['name'], $label );
+			function( array $label ) : Label {
+				return static::import_bootstrap_label( (string) $label['name'], $label );
 			},
 			static::get_bootstrap_labels()
 		);
@@ -256,7 +256,7 @@ class Label_Store {
 		/**
 		 * Add your own labels or adjust the defaults using this filter.
 		 *
-		 * @hook  Figuren_Theater\Label_Printing\Patterns\bootstrap_labels
+		 * Use this hook: 'Figuren_Theater\Label_Printing\Patterns\bootstrap_labels'.
 		 * @since 0.2.0
 		 *
 		 * @phpstan-ignore-next-line phpDoc.parseError

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -131,7 +131,7 @@ class Label_Store {
 	protected static function label_factory_from_wp_posts( \WP_Query $query ) : array {
 
 		return \array_filter( \array_map(
-			function( int|\WP_Post $post ) : Label|null {
+			function( int|\WP_Post $post ) : ?Label {
 
 				// Prepare Data.
 				$post = \get_post( $post );

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -169,7 +169,7 @@ class Label_Store {
 	 */
 	protected static function label_factory_from_wp_posts( \WP_Query $query ) : array {
 		return \array_filter( \array_map(
-			static::get_label_by_post( $post ),
+			static::get_label_by_post( $post );
 			$query->posts
 		));
 	}

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -169,7 +169,9 @@ class Label_Store {
 	 */
 	protected static function label_factory_from_wp_posts( \WP_Query $query ) : array {
 		return \array_filter( \array_map(
-			__NAMESPACE__ . '\\get_label_by_post',
+			function( $post ){
+				return static::get_label_by_post( $post );
+			},
 			$query->posts
 		));
 	}

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -31,7 +31,7 @@ class Label_Store {
 		// If $labels is still an empty list,
 		// nobody has used our filter, so we query our DB instead.
 		if ( empty( $labels ) ) {
-			$labels = $this->get_stored_labels();
+			$labels = static::get_stored_labels();
 		}
 
 		return $labels;
@@ -56,7 +56,7 @@ class Label_Store {
 	 *
 	 * @return Label[] An array of Label objects.
 	 */
-	function get_stored_labels() : array {
+	public static function get_stored_labels() : array {
 
 		// Check if the value is already stored.
 		$stored_labels = \get_transient( TRANSIENT_KEY );
@@ -67,7 +67,7 @@ class Label_Store {
 			$stored_labels = static::query_labels();
 
 			// Store for long,
-			// because this will beflushed with every new (and updated) 'wp_block' post.
+			// because this will be flushed with every new (and updated) 'wp_block' post.
 			\set_transient(
 				TRANSIENT_KEY,
 				$stored_labels,

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -220,7 +220,7 @@ class Label_Store {
 	public static function get_bootstrap_labels() : array {
 		$bootstrap_labels = [
 			[
-				'name'         => 'A6 Landscape',
+				'name'         => _x( 'A6 Landscape', 'label-printing' ),
 				'width'        => 148,
 				'height'       => 105,
 				'a4_border_tb' => 0,
@@ -228,7 +228,7 @@ class Label_Store {
 				'orientation'  => 'landscape',
 			],
 			[
-				'name'         => 'A6 Landscape (with Top-Bottom-Borders)',
+				'name'         => _x( 'A6 Landscape (with Top-Bottom-Borders)', 'label-printing' ),
 				'width'        => 148,
 				'height'       => 90,
 				'a4_border_tb' => 15,
@@ -236,7 +236,7 @@ class Label_Store {
 				'orientation'  => 'landscape',
 			],
 			[
-				'name'         => 'A8 Portrait',
+				'name'         => _x( 'A8 Portrait', 'label-printing' ),
 				'width'        => 52.5,
 				'height'       => 74,
 				'a4_border_tb' => 0,
@@ -244,7 +244,7 @@ class Label_Store {
 				'orientation'  => 'portrait',
 			],
 			[
-				'name'         => 'A8 Landscape',
+				'name'         => _x( 'A8 Landscape', 'label-printing' ),
 				'width'        => 74,
 				'height'       => 52.5,
 				'a4_border_tb' => 0,
@@ -332,8 +332,8 @@ class Label_Store {
 				'public'            => false,
 				'hierarchical'      => false,
 				'labels'            => [
-					'name'          => _x( 'Pattern Categories', 'taxonomy general name' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-					'singular_name' => _x( 'Pattern Category', 'taxonomy singular name' ), // phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+					'name'          => _x( 'Pattern Categories', 'taxonomy general name', 'label-printing' ),
+					'singular_name' => _x( 'Pattern Category', 'taxonomy singular name', 'label-printing' ),
 				],
 				'query_var'         => false,
 				'rewrite'           => false,

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -206,8 +206,8 @@ class Label_Store {
 	public static function import_bootstrap_labels() : array {
 		return \array_map(
 			function( array $label ): void {
-				static::import_bootstrap_label( $label['name'], $label ),
-			}
+				static::import_bootstrap_label( $label['name'], $label );
+			},
 			static::get_bootstrap_labels()
 		);
 	}

--- a/inc/patterns/class-label-store.php
+++ b/inc/patterns/class-label-store.php
@@ -169,7 +169,7 @@ class Label_Store {
 	 */
 	protected static function label_factory_from_wp_posts( \WP_Query $query ) : array {
 		return \array_filter( \array_map(
-			static::get_label_by_post( $post );
+			__NAMESPACE__ . '\\get_label_by_post',
 			$query->posts
 		));
 	}

--- a/inc/patterns/class-label.php
+++ b/inc/patterns/class-label.php
@@ -68,9 +68,9 @@ class Label {
 	/**
 	 * Setup and instantiate a new Label.
 	 *
-	 * @param  string $name   Human readable name
-	 * @param  float  $width  Width in mm
-	 * @param  float  $height Height in mm
+	 * @param  string $name   Human readable name.
+	 * @param  float  $width  Width in mm.
+	 * @param  float  $height Height in mm.
 	 */
 	public function __construct( string $name, float $width, float $height ) {
 		$this->name   = $name;

--- a/inc/patterns/namespace.php
+++ b/inc/patterns/namespace.php
@@ -21,7 +21,7 @@ const STATIC_PATTERN_CATEGORY = TRANSIENT_KEY;
  *
  * @return void
  */
-function register() :void {
+function register(): void {
 	\add_action( 'init', __NAMESPACE__ . '\\bootstrap' );
 }
 
@@ -30,9 +30,9 @@ function register() :void {
  *
  * @return void
  */
-function bootstrap() :void {
+function bootstrap(): void {
 
-	$store = new Label_Store;
+	$store = new Label_Store();
 
 	// Flush the cache after each import.
 	\add_action(
@@ -53,23 +53,23 @@ function bootstrap() :void {
 		[
 			// Importantly object refers to a JSON object,
 			// this is equivalent to an associative array in PHP.
-			'type' => 'object',
-			'description' => 'Physical measurements of a printing label.',
-			'single' => true,
+			'type'         => 'object',
+			'description'  => 'Physical measurements of a printing label.',
+			'single'       => true,
 			'show_in_rest' => [
 				'schema' => [
 					'type'       => 'object',
 					'properties' => [
-						'width' => [
+						'width'        => [
 							'type' => 'number',
 						],
-						'height'  => [
+						'height'       => [
 							'type' => 'number',
 						],
 						'a4_border_tb' => [
 							'type' => 'number',
 						],
-						'a4_border_lr'  => [
+						'a4_border_lr' => [
 							'type' => 'number',
 						],
 						'orientation'  => [
@@ -89,7 +89,7 @@ function bootstrap() :void {
  *
  * @return void
  */
-function register_block_patterns( Label $label ) : void {
+function register_block_patterns( Label $label ): void {
 
 	// Instantiate new pattern generator.
 	$generator = new Generator( $label );
@@ -122,7 +122,7 @@ function register_block_patterns( Label $label ) : void {
  *
  * @return void
  */
-function register_block_pattern_category() : void {
+function register_block_pattern_category(): void {
 	\register_block_pattern_category(
 		STATIC_PATTERN_CATEGORY,
 		[

--- a/inc/patterns/namespace.php
+++ b/inc/patterns/namespace.php
@@ -39,6 +39,10 @@ function bootstrap(): void {
 		__NAMESPACE__ . '\\save_post_wp_block_label',
 		[ $store, 'delete_transient' ]
 	);
+	\add_action(
+		'save_post_wp_block',
+		[ $store, 'delete_transient' ]
+	);
 
 	// Register a new pattern category.
 	register_block_pattern_category();

--- a/plugin.php
+++ b/plugin.php
@@ -13,7 +13,7 @@
  * Description:       Create printable labels with blocks.
  * Version:           0.2.0
  * Requires at least: 6.2
- * Requires PHP:      7.4
+ * Requires PHP:      8.1
  * Author:            Carsten Bach
  * Author URI:        https://figuren.theater/crew
  * Text Domain:       label-printing

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Register the label-printing plugin
  *
  * @package           figuren-theater/label-printing
- * @author            figuren.theater Crew
+ * @author            Carsten Bach
  * @copyright         2023 figuren.theater
  * @license           GPL-3.0+
  *
@@ -14,7 +14,7 @@
  * Version:           0.2.0
  * Requires at least: 6.2
  * Requires PHP:      7.4
- * Author:            figuren.theater Crew
+ * Author:            Carsten Bach
  * Author URI:        https://figuren.theater/crew
  * Text Domain:       label-printing
  * Domain Path:       /languages
@@ -30,7 +30,7 @@ const DIRECTORY = __DIR__;
 /**
  * REMOVE
  *
- * @todo #15 Add composer autoloading strategy
+ * @todo Add composer autoloading strategy https://github.com/figuren-theater/label-printing/issues/15
  */
 require_once DIRECTORY . '/inc/blocks/namespace.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 require_once DIRECTORY . '/inc/block-styles/namespace.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
@@ -41,4 +41,4 @@ require_once DIRECTORY . '/inc/patterns/class-label-store.php'; // phpcs:ignore 
 require_once DIRECTORY . '/inc/patterns/namespace.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 require_once DIRECTORY . '/inc/namespace.php'; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
 
-\add_action( 'init', __NAMESPACE__ . '\\register', 0 );
+\add_action( 'init', __NAMESPACE__ . '\\register', 0 ); // 0 is important

--- a/src/block-editor/blocks/label-printing/edit.js
+++ b/src/block-editor/blocks/label-printing/edit.js
@@ -85,7 +85,10 @@ export default function Edit({
 						[
 							'core/paragraph',
 							{
-								placeholder: __('Enter label content...', 'label-printing'),
+								placeholder: __(
+									'Enter label content…',
+									'label-printing'
+								),
 								style: {
 									spacing: {
 										margin: {

--- a/src/block-editor/blocks/label-printing/edit.js
+++ b/src/block-editor/blocks/label-printing/edit.js
@@ -45,7 +45,7 @@ export default function Edit({
 		[
 			'core/heading',
 			{
-				placeholder: 'Title',
+				placeholder: __('Label Title', 'label-printing'),
 				style: {
 					spacing: {
 						margin: {
@@ -85,7 +85,7 @@ export default function Edit({
 						[
 							'core/paragraph',
 							{
-								placeholder: 'Enter side content...',
+								placeholder: __('Enter label content...', 'label-printing'),
 								style: {
 									spacing: {
 										margin: {

--- a/src/block-editor/blocks/label-printing/editor.scss
+++ b/src/block-editor/blocks/label-printing/editor.scss
@@ -18,6 +18,10 @@
 		overflow: hidden;
 		transition: width, height 0.3s cubic-bezier(0.9, 0.26, 0.18, 0.77);
 		margin-left: 2vw;
+
+		// padding: 20px; // safety disatnce
+		padding: calc(var(--label-printing-height)*.1) calc(var(--label-printing-width)*.1);
+		box-sizing: border-box;
 	}
 
 	.wp-block-group.alignwide[class*="is-style-label-overview-"] {

--- a/src/block-editor/blocks/label-printing/editor.scss
+++ b/src/block-editor/blocks/label-printing/editor.scss
@@ -20,7 +20,7 @@
 		margin-left: 2vw;
 
 		// padding: 20px; // safety disatnce
-		padding: calc(var(--label-printing-height)*.1) calc(var(--label-printing-width)*.1);
+		padding: calc(var(--label-printing-height) * 0.1) calc(var(--label-printing-width) * 0.1);
 		box-sizing: border-box;
 	}
 

--- a/src/block-editor/blocks/label-printing/index.php
+++ b/src/block-editor/blocks/label-printing/index.php
@@ -8,7 +8,6 @@
 namespace Figuren_Theater\Label_Printing\Blocks\Printing;
 
 use Figuren_Theater\Label_Printing\Patterns;
-use Figuren_Theater\Network\Blocks\Patterns as BlocksPatterns;
 
 /**
  * Render callback of the 'figuren-theater/label-printing' block.
@@ -19,7 +18,7 @@ use Figuren_Theater\Network\Blocks\Patterns as BlocksPatterns;
  *
  * @return string
  */
-function render( array $attributes ) : string {
+function render( array $attributes ): string {
 
 	// Get the label post object based on the provided attribute.
 	$label = \get_post( $attributes['wpLabelPost'] );
@@ -37,8 +36,8 @@ function render( array $attributes ) : string {
 	if ( ! \is_array( $meta ) || ! isset( $meta['height'] ) || ! isset( $meta['width'] ) ) {
 		return '';
 	}
-	$attributes['labelHeight']  = $meta['height'];
-	$attributes['labelWidth']   = $meta['width'];
+	$attributes['labelHeight'] = $meta['height'];
+	$attributes['labelWidth']  = $meta['width'];
 
 	$attributes['a4_border_tb'] = $meta['a4_border_tb'];
 	$attributes['a4_border_lr'] = $meta['a4_border_lr'];

--- a/src/block-editor/blocks/label-printing/style.scss
+++ b/src/block-editor/blocks/label-printing/style.scss
@@ -33,10 +33,9 @@ body.is-label-printing {
 }
 
 @media print {
-
-	html,
-	body,
-	.wp-site-blocks {
+	// html,
+	body.is-label-printing,
+	.is-label-printing .wp-site-blocks {
 		margin: 0 !important;
 		padding: 0 !important;
 	}

--- a/src/block-editor/blocks/label-printing/style.scss
+++ b/src/block-editor/blocks/label-printing/style.scss
@@ -5,6 +5,15 @@
  * .wp-block-figuren-theater-label-printing {}
  */
 
+// Disable WordPress' root padding
+body.is-label-printing {
+	--wp--style--root--padding-left: 0 !important;
+	--wp--style--root--padding-right: 0 !important;
+
+	* {
+		box-shadow: none !important;
+	}
+}
 
 .wp-block-group.alignwide[class*="is-style-label-overview-"] {
 	max-width: var(--label-printing-doc-width) !important;

--- a/src/block-editor/blocks/label-printing/style.scss
+++ b/src/block-editor/blocks/label-printing/style.scss
@@ -30,9 +30,30 @@ body.is-label-printing {
 		box-sizing: border-box;
 
 	}
+	/* 		// for debug
+	> .wp-block-group > *:before{
+		content: var(--label-printing-orientation);
+	} */
 }
-
+@page portrait {
+	size: A4 portrait;
+	page-orientation: upright;
+	// margin: auto;
+}
+@page landscape {
+	size: A4 landscape;
+	// page-orientation: rotate-left;
+}
+  
 @media print {
+	.is-label-printing {
+		page: var(--label-printing-orientation);
+	}
+	// @page {
+	// 	// size: landscape;
+	// 	size: A4 var(--label-printing-orientation);
+	// }
+
 	// html,
 	body.is-label-printing,
 	.is-label-printing .wp-site-blocks {
@@ -41,14 +62,15 @@ body.is-label-printing {
 	}
 
 	.wp-block-group.alignwide[class*="is-style-label-overview-"] {
-		page-break-before: always;
+		// page-break-before: always;
 		page-break-after: always;
+		break-after: page;
 		padding: var(--label-printing-a4-border-tb, 0) var(--label-printing-a4-border-lr, 0) !important;
 
-		/* 		// for debug
+		/* 	// for debug
 		> .wp-block-group > * {
 			outline: 1px dashed var(--wp--preset--color--foreground, rgb(128, 128, 128));
-		} */
+		}	 */
 	}
 }
 
@@ -57,7 +79,7 @@ body.is-label-printing {
 	.wp-block-group.alignwide[class*="is-style-label-overview-"] {
 
 		box-shadow: 0.1em 0.1em 0.3em var(--wp--preset--color--primary, rgb(128, 128, 128));
-		margin-top: 5vw !important;
+		margin-top: 10vw !important;
 		margin-bottom: 5vw !important;
 
 		> .wp-block-group > * {

--- a/src/block-editor/blocks/label-printing/style.scss
+++ b/src/block-editor/blocks/label-printing/style.scss
@@ -26,26 +26,30 @@ body.is-label-printing {
 		max-width: var(--label-printing-width) !important;
 
 		// padding: 20px; // safety disatnce
-		padding: calc(var(--label-printing-height)*.1) calc(var(--label-printing-width)*.1); // safety disatnce
+		padding: calc(var(--label-printing-height) * 0.1) calc(var(--label-printing-width) * 0.1); // safety disatnce
 		box-sizing: border-box;
 
 	}
+
 	/* 		// for debug
 	> .wp-block-group > *:before{
 		content: var(--label-printing-orientation);
 	} */
 }
+
 @page portrait {
-	size: A4 portrait;
+	size: a4 portrait;
 	page-orientation: upright;
 	// margin: auto;
 }
+
 @page landscape {
-	size: A4 landscape;
+	size: a4 landscape;
 	// page-orientation: rotate-left;
 }
-  
+
 @media print {
+
 	.is-label-printing {
 		page: var(--label-printing-orientation);
 	}

--- a/src/block-editor/blocks/label-printing/style.scss
+++ b/src/block-editor/blocks/label-printing/style.scss
@@ -24,6 +24,11 @@ body.is-label-printing {
 		overflow: hidden;
 		max-height: var(--label-printing-height) !important;
 		max-width: var(--label-printing-width) !important;
+
+		// padding: 20px; // safety disatnce
+		padding: calc(var(--label-printing-height)*.1) calc(var(--label-printing-width)*.1); // safety disatnce
+		box-sizing: border-box;
+
 	}
 }
 

--- a/src/block-editor/blocks/label-proxy/index.php
+++ b/src/block-editor/blocks/label-proxy/index.php
@@ -34,7 +34,7 @@ function render(): string {
 			\ob_start();
 			foreach ( $block['innerBlocks'] as $block ) {
 				echo \wp_kses_post(
-					\apply_filters(
+					\apply_filters( // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 						'the_content',
 						\render_block( $block )
 					)

--- a/src/block-editor/blocks/label-proxy/index.php
+++ b/src/block-editor/blocks/label-proxy/index.php
@@ -16,7 +16,7 @@ namespace Figuren_Theater\Label_Printing\Blocks\Proxy;
  *
  * @return string
  */
-function render() : string {
+function render(): string {
 
 	$post = \get_post();
 
@@ -46,5 +46,4 @@ function render() : string {
 
 	// If not already exited.
 	return '';
-
 }


### PR DESCRIPTION
## *What has changed?*:

- Disable WordPress' root padding [cff7e92](https://github.com/figuren-theater/label-printing/pull/41/commits/cff7e92a8a0d683debd1af92c166812f66aa10c8)
- Add 10% inner saftey distance to all labels [779f2bf](https://github.com/figuren-theater/label-printing/pull/41/commits/779f2bf4b5c4c065c213995ee0184bbe539c4c06)
- Make template strings translateable [1ddbc50](https://github.com/figuren-theater/label-printing/pull/41/commits/1ddbc50b67e3e5eb92f7da296a0ae39c6180f453)
- Add body-class when block is in use [293ca9a](https://github.com/figuren-theater/label-printing/pull/41/commits/293ca9a467f95e0947cde1b33471e9f17164c192)
- Recognise paper orientation in browser print dialog [4942323](https://github.com/figuren-theater/label-printing/pull/41/commits/49423234f3fb377ca9880b96044b8c73cebfab85)
- NEW FAQ 'How does the block work?' [a607b2d](https://github.com/figuren-theater/label-printing/pull/41/commits/a607b2d0690d6cbb807c00b1609702d0f3f48314)
- Try to better align with plugin-readme guidelines [45a21b7](https://github.com/figuren-theater/label-printing/pull/41/commits/45a21b741abf87f59159df6f2fa025f904442379)
- Increase minimum required PHP to 8.1 )

## *Why was it needed?*:

#6 

---

### Code Checklist
- [ ] tested
- [x] documented
