### PR TITLE
Hook into (f.t) prerelease-changelog-update workflow and also update wporg related versions in other files

### DIFF
--- a/.github/workflows/prerelease-changelog.yml
+++ b/.github/workflows/prerelease-changelog.yml
@@ -10,3 +10,4 @@ jobs:
     uses: figuren-theater/.github/.github/workflows/prerelease-changelog-update.yml@main
     secrets: inherit
 
+# @TODO add 'wordpress-org-deploy.yml' && 'wordpress-org-version-numbers.yml' as callable workflows from here.

--- a/.github/workflows/wordpress-org-deploy.yml
+++ b/.github/workflows/wordpress-org-deploy.yml
@@ -14,7 +14,7 @@ on:
   # release:
   #   types: [edited]
   push:
-    commit_message: 'Update version to '
+    commit_message: 'Update wporg-related-version to '
     # branches:
       # - main
 
@@ -22,8 +22,8 @@ jobs:
   deploy-to-wp-repository:
     name: Deploy to WP.org
     runs-on: ubuntu-latest
-    # if: github.event.release.edited == true && contains(github.event.head_commit.message, 'Update version to ')
-    if: contains(github.event.head_commit.message, 'Update version to ')
+    # if: github.event.release.edited == true && contains(github.event.head_commit.message, 'Update wporg-related-version to ')
+    if: contains(github.event.head_commit.message, 'Update wporg-related-version to ')
     steps:
  
       # - name: Checkout code

--- a/.github/workflows/wordpress-org-version-numbers.yml
+++ b/.github/workflows/wordpress-org-version-numbers.yml
@@ -17,7 +17,7 @@ jobs:
     # Condition looks for numbered releases (1.27.3 for example) AND a specific part of a commit msg.
     if: 'latest' !== github.event.release.tag_name && contains(github.event.head_commit.message, 'Update version to ')
     # 'Update version to ' is part of an automated commit by @figuren-theater-bot
-    # during the 'figuren-theater/... prerelease-and-update-changelog' action.
+    # during the 'figuren-theater/.github/.github/workflows/prerelease-changelog-update.yml@main' action.
     # This kind of commit runs everywhere in the ft-space.
     #
     # Now, we check if there are some files, that are typically only relevant for *real* plugins.

--- a/.github/workflows/wordpress-org-version-numbers.yml
+++ b/.github/workflows/wordpress-org-version-numbers.yml
@@ -1,0 +1,69 @@
+name: Update version numbers for WordPress.org Repository
+
+on:
+  # release:
+  #   types: [published]
+  #   types: [edited]
+  push:
+    commit_message: 'Update version to '
+    # branches:
+      # - main
+
+jobs:
+  update-version-numbers-for-wp-repository:
+    name: Update Version numbers for WP.org
+    runs-on: ubuntu-latest
+
+    # Condition looks for numbered releases (1.27.3 for example) AND a specific part of a commit msg.
+    if: 'latest' !== github.event.release.tag_name && contains(github.event.head_commit.message, 'Update version to ')
+    # 'Update version to ' is part of an automated commit by @figuren-theater-bot
+    # during the 'figuren-theater/... prerelease-and-update-changelog' action.
+    # This kind of commit runs everywhere in the ft-space.
+    #
+    # Now, we check if there are some files, that are typically only relevant for *real* plugins.
+    # Means, plugins which are published to the wp.org/plugins repo, and not ft-modules of any kind.
+    steps:
+      - name: Checkout code
+        # Push to protected branches
+        # If your repository uses protected branches you have to make some changes
+        # to your Workflow for the Action to work properly:
+        #
+        # You need a Personal Access Token and you either have to
+        # a) allow force pushes
+        # or
+        # b) the Personal Access Token needs to belong to an Administrator.
+        #
+        # Add the following to 'with:' 'token: ${{ secrets.PAT }}'
+        #
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          ref: ${{ github.event.release.target_commitish }}
+
+      # @TODO https://github.com/figuren-theater/.github/issues/57 Automatically bump version in all relevant files
+      - name: Update version number in files
+        env:
+          NEW_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+
+          if [ -f readme.md ]; then
+            echo "NEW version in readme.md: $NEW_VERSION"
+            sed -ri "s/(Stable tag:[[:space:]]*)[0-9]+\.[0-9]+\.[0-9]+/\\1$NEW_VERSION/g" readme.md
+            git commit -am "Update wporg-related-version to $NEW_VERSION"
+          fi
+
+          # if [ -f package.json ]; then
+          #   echo "NEW version in package.json: $NEW_VERSION"
+          #   sed -ri "s/(Stable tag:[[:space:]]*)[0-9]+\.[0-9]+\.[0-9]+/\\1$NEW_VERSION/g" package.json
+          #   git commit -am "Update version to $NEW_VERSION"
+          # fi
+
+      - name: Push to protected branch
+        uses: CasperWA/push-protected@v2
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+          # branch: ${{ github.event.release.target_commitish }}
+          branch: main
+          #unprotect_reviews: true # has anoying side-effect: settings stays disabled if workflow fails
+          acceptable_conclusions: success,skipped # A comma-separated list of acceptable statuses. If any of these statuses are present, the action will not fail.
+

--- a/.github/workflows/wordpress-org-version-numbers.yml
+++ b/.github/workflows/wordpress-org-version-numbers.yml
@@ -7,7 +7,7 @@ on:
   push:
     commit_message: 'Update version to '
     # branches:
-      # - main
+    #   - main
 
 jobs:
   update-version-numbers-for-wp-repository:
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     # Condition looks for numbered releases (1.27.3 for example) AND a specific part of a commit msg.
-    if: 'latest' !== github.event.release.tag_name && contains(github.event.head_commit.message, 'Update version to ')
+    # v1
+    # if: 'latest' !== github.event.release.tag_name && contains(github.event.head_commit.message, 'Update version to ')
+    # v2
+    if: ( github.event.release.tag_name && 'latest' != github.event.release.tag_name && contains(github.event.head_commit.message, 'Update version to ') )
     # 'Update version to ' is part of an automated commit by @figuren-theater-bot
     # during the 'figuren-theater/.github/.github/workflows/prerelease-changelog-update.yml@main' action.
     # This kind of commit runs everywhere in the ft-space.


### PR DESCRIPTION
## *What has changed?*:

## *Why was it needed?*:

Need(ed) to change "Stable tag:" and "version" in `readme.md` and `package.json` manually for too long. 

**If forgotten**, the following "plugin review guidelines" will trigger an error on ',mismatched version numbers'. *I know*

## *How was it done?*:

## Links to trello Tickets or github issues: 

* 

---

### Code Checklist
- [ ] tested
- [ ] documented
