### PR TITLE
Update Plugin Check action name

### DIFF
--- a/.github/workflows/wordpress-org-plugin-guidelines.yml
+++ b/.github/workflows/wordpress-org-plugin-guidelines.yml
@@ -40,7 +40,7 @@ jobs:
           mkdir tmp-build
           unzip label-printing.zip -d tmp-build
       - name: Run plugin check
-        uses: swissspidy/wp-plugin-check-action@main
+        uses: wordpress/plugin-check-action@v1
         with:
           build-dir: './tmp-build/label-printing'
           wp-version: 'trunk'


### PR DESCRIPTION
## *What has changed?*:

The Plugin Check GitHub action is now part of the WordPress organization

## *Why was it needed?*:

## *How was it done?*:

## Links to trello Tickets or github issues: 

* 

---

### Code Checklist
- [x] tested
- [x] documented
